### PR TITLE
add more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ fn main() {
     // Create some example input data
     let input = Array2::from_shape_vec((input_size, 1), vec![0.5, 0.1, -0.3]).unwrap();
 
+    // Initialize the hidden state and cell state
+    let hx = Array2::zeros((hidden_size, 1));
+    let cx = Array2::zeros((hidden_size, 1));
+
     // Perform a forward pass
-    let output = network.forward(&input);
+    let (output, _) = network.forward(&input, &hx, &cx);
 
     // Print the output
     println!("Output: {:?}", output);

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -12,8 +12,12 @@ fn main() {
     // Create some example input data
     let input = Array2::from_shape_vec((input_size, 1), vec![0.5, 0.1, -0.3]).unwrap();
 
+    // Initialize the hidden state and cell state
+    let hx = Array2::zeros((hidden_size, 1));
+    let cx = Array2::zeros((hidden_size, 1));
+
     // Perform a forward pass
-    let output = network.forward(&input);
+    let (output, _) = network.forward(&input, &hx, &cx);
 
     // Print the output
     println!("Output: {:?}", output);

--- a/examples/multi_layer_lstm.rs
+++ b/examples/multi_layer_lstm.rs
@@ -1,0 +1,35 @@
+use ndarray::Array2;
+use rust_lstm::models::lstm_network::LSTMNetwork;
+
+fn main() {
+    let input_size = 3;
+    let hidden_size = 2;
+    let num_layers = 3;
+    let sequence_length = 5;
+
+    // Create a multi-layer LSTM network
+    let network = LSTMNetwork::new(input_size, hidden_size, num_layers);
+
+    // Create a sequence of example input data
+    let sequence = (0..sequence_length).map(|i| {
+        Array2::from_shape_vec((input_size, 1), vec![i as f64 * 0.1, i as f64 * 0.2, i as f64 * 0.3]).unwrap()
+    }).collect::<Vec<_>>();
+
+    // Initialize the hidden state and cell state
+    let mut hx = Array2::zeros((hidden_size, 1));
+    let mut cx = Array2::zeros((hidden_size, 1));
+
+    // Process the sequence through the LSTM network
+    let mut outputs = Vec::new();
+    for input in sequence {
+        let (new_hx, new_cx) = network.forward(&input, &hx, &cx);
+        outputs.push(new_hx.clone());
+        hx = new_hx;
+        cx = new_cx;
+    }
+
+    // Print the outputs
+    for (i, output) in outputs.iter().enumerate() {
+        println!("Output for sequence step {}: {:?}", i, output);
+    }
+}

--- a/examples/text_generation.rs
+++ b/examples/text_generation.rs
@@ -1,0 +1,62 @@
+use ndarray::{Array2, Array3, s};
+use rust_lstm::models::lstm_network::LSTMNetwork;
+use std::collections::HashMap;
+
+fn main() {
+    // Define the text and the set of characters
+    let text = "hello world";
+    let chars: Vec<char> = text.chars().collect();
+    let unique_chars: Vec<char> = chars.iter().cloned().collect::<std::collections::HashSet<_>>().into_iter().collect();
+    let char_to_idx: HashMap<char, usize> = unique_chars.iter().cloned().enumerate().map(|(i, c)| (c, i)).collect();
+    let idx_to_char: HashMap<usize, char> = char_to_idx.iter().map(|(&c, &i)| (i, c)).collect();
+    let input_size = unique_chars.len();
+    let hidden_size = 10;
+    let num_layers = 2;
+    let sequence_length = 5;
+
+    // Create an LSTM network
+    let network = LSTMNetwork::new(input_size, hidden_size, num_layers);
+
+    // Prepare the input sequence
+    let input_text = "hello";
+    let input_indices: Vec<usize> = input_text.chars().map(|c| *char_to_idx.get(&c).unwrap()).collect();
+    let mut input = Array3::zeros((sequence_length, input_size, 1));
+    for (t, &idx) in input_indices.iter().enumerate() {
+        input.slice_mut(s![t, idx, ..]).fill(1.0);
+    }
+
+    // Initialize the hidden state and cell state
+    let mut hx = Array2::zeros((hidden_size, 1));
+    let mut cx = Array2::zeros((hidden_size, 1));
+
+    // Process the sequence through the LSTM network
+    for t in 0..sequence_length {
+        let input_t = input.slice(s![t, .., ..]).to_owned();
+        let (new_hx, new_cx) = network.forward(&input_t, &hx, &cx);
+        hx = new_hx;
+        cx = new_cx;
+    }
+
+    // Generate the next characters
+    let mut generated_text = input_text.to_string();
+    let num_generated_chars = 20;
+    for _ in 0..num_generated_chars {
+        // Create a one-hot encoded input from the current hidden state
+        let mut input_t = Array2::zeros((input_size, 1));
+        let output_idx = hx.iter().cloned().enumerate().max_by(|a, b| a.1.partial_cmp(&b.1).unwrap()).unwrap().0;
+        input_t.slice_mut(s![output_idx, ..]).fill(1.0);
+
+        // Perform the forward pass
+        let (new_hx, new_cx) = network.forward(&input_t, &hx, &cx);
+        hx = new_hx;
+        cx = new_cx;
+
+        // Get the predicted character
+        let output_idx = hx.iter().cloned().enumerate().max_by(|a, b| a.1.partial_cmp(&b.1).unwrap()).unwrap().0;
+        let output_char = idx_to_char[&output_idx];
+        generated_text.push(output_char);
+    }
+
+    // Print the generated text
+    println!("Generated text: {}", generated_text);
+}

--- a/examples/time_series_prediction.rs
+++ b/examples/time_series_prediction.rs
@@ -1,0 +1,33 @@
+use ndarray::Array2;
+use rust_lstm::models::lstm_network::LSTMNetwork;
+
+fn main() {
+    let input_size = 1; // The input size should match the feature dimension of the input data
+    let hidden_size = 10;
+    let num_layers = 2;
+    let sequence_length = 10;
+
+    // Create an LSTM network
+    let network = LSTMNetwork::new(input_size, hidden_size, num_layers);
+
+    // Generate a simple sine wave as input data
+    let sequence = (0..sequence_length).map(|i| {
+        Array2::from_shape_vec((input_size, 1), vec![(i as f64 * 0.1).sin()]).unwrap()
+    }).collect::<Vec<_>>();
+
+    // Process the sequence through the LSTM network
+    let mut outputs = Vec::new();
+    let mut hx = Array2::zeros((hidden_size, 1));
+    let mut cx = Array2::zeros((hidden_size, 1));
+    for input in sequence {
+        let (new_hx, new_cx) = network.forward(&input, &hx, &cx);
+        outputs.push(new_hx.clone());
+        hx = new_hx;
+        cx = new_cx;
+    }
+
+    // Print the outputs
+    for (i, output) in outputs.iter().enumerate() {
+        println!("Predicted value at step {}: {:?}", i, output);
+    }
+}

--- a/src/models/lstm_network.rs
+++ b/src/models/lstm_network.rs
@@ -1,13 +1,11 @@
 use ndarray::Array2;
 use crate::layers::lstm_cell::LSTMCell;
 
-/// LSTM network struct containing multiple LSTM cells.
 pub struct LSTMNetwork {
     cells: Vec<LSTMCell>,
 }
 
 impl LSTMNetwork {
-    /// Creates a new LSTM network with the specified number of layers.
     pub fn new(input_size: usize, hidden_size: usize, num_layers: usize) -> Self {
         let mut cells = Vec::new();
         for _ in 0..num_layers {
@@ -16,11 +14,9 @@ impl LSTMNetwork {
         LSTMNetwork { cells }
     }
 
-    /// Performs a forward pass through the LSTM network.
-    pub fn forward(&self, input: &Array2<f64>) -> Array2<f64> {
-        let hidden_size = self.cells[0].hidden_size;
-        let mut hx = Array2::zeros((hidden_size, 1));
-        let mut cx = Array2::zeros((hidden_size, 1));
+    pub fn forward(&self, input: &Array2<f64>, hx: &Array2<f64>, cx: &Array2<f64>) -> (Array2<f64>, Array2<f64>) {
+        let mut hx = hx.clone();
+        let mut cx = cx.clone();
 
         for cell in &self.cells {
             let (new_hx, new_cx) = cell.forward(input, &hx, &cx);
@@ -28,7 +24,7 @@ impl LSTMNetwork {
             cx = new_cx;
         }
 
-        hx
+        (hx, cx)
     }
 }
 
@@ -45,8 +41,12 @@ mod tests {
         let network = LSTMNetwork::new(input_size, hidden_size, num_layers);
 
         let input = arr2(&[[0.5], [0.1], [-0.3]]);
-        let output = network.forward(&input);
+        let hx = arr2(&[[0.0], [0.0]]);
+        let cx = arr2(&[[0.0], [0.0]]);
 
-        assert_eq!(output.shape(), &[hidden_size, 1]);
+        let (hy, cy) = network.forward(&input, &hx, &cx);
+
+        assert_eq!(hy.shape(), &[hidden_size, 1]);
+        assert_eq!(cy.shape(), &[hidden_size, 1]);
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,7 +9,13 @@ fn test_lstm_network_integration() {
     let network = LSTMNetwork::new(input_size, hidden_size, num_layers);
 
     let input = arr2(&[[0.5], [0.1], [-0.3]]);
-    let output = network.forward(&input);
+
+    // Initialize the hidden state and cell state
+    let hx = arr2(&[[0.0], [0.0]]);
+    let cx = arr2(&[[0.0], [0.0]]);
+
+    // Perform a forward pass
+    let (output, _) = network.forward(&input, &hx, &cx);
 
     assert_eq!(output.shape(), &[hidden_size, 1]);
 }


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and usage of the LSTM network. The changes mainly focus on modifying the forward pass method to include hidden and cell states, and adding new examples demonstrating the usage of the LSTM network in different scenarios.

### Changes to LSTM Network:

* Modified the `forward` method in `LSTMNetwork` to include hidden and cell states as parameters and return both states. (`src/models/lstm_network.rs`)

### Examples:

* Added new example `multi_layer_lstm.rs` to demonstrate the usage of a multi-layer LSTM network. (`examples/multi_layer_lstm.rs`)
* Added new example `text_generation.rs` to demonstrate text generation using the LSTM network. (`examples/text_generation.rs`)
* Added new example `time_series_prediction.rs` to demonstrate time series prediction using the LSTM network. (`examples/time_series_prediction.rs`)

### Updates to Existing Examples:

* Updated `README.md` and `examples/basic_usage.rs` to initialize and pass hidden and cell states during the forward pass. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R57) (`examples/basic_usage.rs`) [[2]](diffhunk://#diff-09f868950297c74c720a604834e21c00d8017c55f143c377988825408b0b7c8aR15-R20)

### Tests:

* Updated tests to initialize and pass hidden and cell states during the forward pass. (`src/models/lstm_network.rs`) [[1]](diffhunk://#diff-3329aadd56b1a100678bb1483231e8476396085569e68fe49882136ab8fe5e5dL48-R50) (`tests/integration_test.rs`) [[2]](diffhunk://#diff-7ff815b68943f08bef79f083c09e55ca8c18db8e25033034b12fa31f1d43dab4L12-R18)